### PR TITLE
feat: add internal metadata to sets, timestamp

### DIFF
--- a/src/keyValueStore.js
+++ b/src/keyValueStore.js
@@ -15,7 +15,8 @@ class KeyValueStore {
    */
   async get (key) {
     if (!this._db) throw new Error('_sync must be called before interacting with the store')
-    return this._db.get(key)
+    const dbGetRes = await this._db.get(key)
+    return dbGetRes ? dbGetRes.value : dbGetRes
   }
 
   /**
@@ -27,7 +28,8 @@ class KeyValueStore {
    */
   async set (key, value) {
     if (!this._db) throw new Error('_sync must be called before interacting with the store')
-    await this._db.put(key, value)
+    const timestamp = new Date().getTime()
+    await this._db.put(key, { value, timestamp })
     return true
   }
 


### PR DESCRIPTION
Adds timestamps to set data. Keeps for internal use for now. We may want to add other additional internal metadata in the future, this starts using it as { value: 'val set by app', timestamp: ..., metadata1: ..., metadata2: ....}. While a get only returns value.  Maybe want to externalize in future.