### PR TITLE
feat: make available time order log/history of store

### DIFF
--- a/src/keyValueStore.js
+++ b/src/keyValueStore.js
@@ -80,6 +80,27 @@ class KeyValueStore {
     if (!this._db) throw new Error('_sync must be called before interacting with the store')
     await this._db.close()
   }
+
+  /**
+   * Returns array of underlying log entries. In linearized order according to their Lamport clocks.
+   * Useful for generating a complete history of all operations on store.
+   *
+   *  @example
+   *  const log = store.log
+   *  const entry = log[0]
+   *  console.log(entry)
+   *  // { op: 'PUT', key: 'Name', value: 'Botbot', timestamp: '1538575416068' }
+   *
+   * @return    {Array<Object>}     Array of ordered log entry objects
+   */
+  get log () {
+    return this._db._oplog.values.map(obj => {
+      return { op: obj.payload.op,
+        key: obj.payload.key,
+        value: obj.payload.value ? obj.payload.value.value : null,
+        timestamp: obj.payload.value ? obj.payload.value.timestamp : null }
+    })
+  }
 }
 
 module.exports = KeyValueStore


### PR DESCRIPTION
One problem related to this PR and the timestamp one is that remove or DEL events don't have timestamps, right not DEL events are still returned but with value null and timestamp null. Probably worth resolving after this.