### PR TITLE
Removed configured bootstrap nodes

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -14,24 +14,6 @@ const utils = require('./utils')
 const ADDRESS_SERVER_URL = 'https://beta.3box.io/address-server'
 const PINNING_SERVER = '/dnsaddr/ipfs.3box.io/tcp/443/wss/ipfs/QmbgpyTLCYBy84E1HGwei6niQHiLQmRpfN6SQtfJiyNMUd'
 const IPFS_OPTIONS = {
-  config: {
-    Addresses: {
-      Swarm: [
-        '/dns4/ws-star.discovery.libp2p.io/tcp/443/wss/p2p-websocket-star'
-      ]
-    },
-    Bootstrap: [
-      '/dns4/ams-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-      '/dns4/lon-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
-      '/dns4/sfo-3.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-      '/dns4/sgp-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
-      '/dns4/nyc-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
-      '/dns4/wss0.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic',
-      '/dns4/wss1.bootstrap.libp2p.io/tcp/443/wss/ipfs/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6',
-      '/dns4/bootstrap.osliki.net/tcp/443/wss/ipfs/QmfJB77qXfiEdJkaSxpZgiMh9kAPiDBj3ga7TxF72QdWtf',
-      '/p2p-circuit/ipfs/QmfJB77qXfiEdJkaSxpZgiMh9kAPiDBj3ga7TxF72QdWtf'
-    ]
-  },
   EXPERIMENTAL: {
     pubsub: true
   }


### PR DESCRIPTION
Did a bunch of experimentation for this one. Overall I decided to stick with the default ipfs bootstrap nodes as it's not much slower (~200ms) and allows us to connect to other browser nodes. It should also be less fragile to rely on ipfs defaults. 

## 1. With bootstrap nodes
Here we kept the configured bootstrap nodes in the ipfs options.
start ipfs: 763ms
start ipfs: 658ms
start ipfs: 720ms
start ipfs: 805ms
start ipfs: 691ms

#### avg: 727.4

## 2. Without bootstrap nodes
Here we removed the bootstrap nodes from the ipfs options, note though that this configuration uses ipfs default bootstrap nodes instead.
start ipfs: 634ms
start ipfs: 648ms
start ipfs: 721ms
start ipfs: 653ms
start ipfs: 674ms

#### avg: 666

## 3. With empty arrays for bootstrap nodes
This option makes ipfs not use it's default bootstrap nodes.
start ipfs: 452ms
start ipfs: 477ms
start ipfs: 443ms
start ipfs: 420ms
start ipfs: 493ms

#### avg: 457

## 4. With only swarm
Uses only swarm nodes (enables connection to other browser nodes)
start ipfs: 640ms
start ipfs: 700ms
start ipfs: 664ms
start ipfs: 715ms
start ipfs: 869ms

#### avg: 717.6

I also wanted to see how long it takes to connect to the pubsub room and the pinning server. In 5 I try the same but with the pinning server as a bootstrap node.
open room, pinning server joined: 3006ms
open room, pinning server joined: 3008ms
open room, pinning server joined: 3040ms
open room, pinning server joined: 3011ms
open room, pinning server joined: 3014ms


## 5. With pinning node as bootnode
Didn't bother as many tests here as it's obvious that things were worse.
start ipfs: 881ms
start ipfs: 686ms

Seems like the bootstrap nodes are not directly connected to which makes the pubsub room entering happen much later.
open room, pinning server joined: 13028ms
open room, pinning server joined: 13367ms
