### PR TITLE
build: package bundler hint to excluded node modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "example:start": "npm run build:dist; node example/server.js",
     "generate-readme": "cp readme-template.md README.md; ./node_modules/.bin/jsdoc2md -g none src/*.js >> README.md"
   },
+  "browser": {
+    "fs": false,
+    "child_process": false
+  },
   "jest": {
     "testEnvironment": "node",
     "testPathIgnorePatterns": [


### PR DESCRIPTION
XMLHttpRequest already does this, and it should be a sufficient hint for any bundler to not include the node modules, but it is not working for a number of people. This makes it more explicit, by specifying the same in our own package. 