### PR TITLE
Publish the dist directory to npm, not lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "3box",
   "version": "1.0.3",
   "description": "Interact with user data",
-  "main": "lib/3box.js",
+  "main": "dist/3box.js",
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
I tried requiring 3box in a project, and got a bunch of babel errors. I realized that this was because the `3box.js` file in the `lib` directory had been published to npm. The compiled file of course, is in `dist/3box.js`.

Maybe there's a good reason for this that I'm not aware of - but as it currently is I can't successfully require 3box in my project.

Example error message (I got over a dozen like this):
```
3box.js:3 Uncaught Error: Cannot find module '@babel/runtime/helpers/interopRequireDefault'
```