### PR TITLE
Always lower-case ethereum addresses that are function inputs

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -208,26 +208,27 @@ class Box {
    * @return    {Box}                                       the 3Box instance for the given address
    */
   static async openBox (address, ethereumProvider, opts = {}) {
+    const normalizedAddress = address.toLowerCase()
     // console.time('-- openBox --')
     let muportDID
-    let serializedMuDID = localstorage.get('serializedMuDID_' + address)
+    let serializedMuDID = localstorage.get('serializedMuDID_' + normalizedAddress)
     if (serializedMuDID) {
       // console.time('new Muport')
       muportDID = new MuPort(serializedMuDID)
       // console.timeEnd('new Muport')
       if (opts.consentCallback) opts.consentCallback(false)
     } else {
-      const sig = await utils.openBoxConsent(address, ethereumProvider)
+      const sig = await utils.openBoxConsent(normalizedAddress, ethereumProvider)
       if (opts.consentCallback) opts.consentCallback(true)
       const entropy = utils.sha256(sig.slice(2))
       const mnemonic = bip39.entropyToMnemonic(entropy)
       // console.time('muport.newIdentity')
       muportDID = await MuPort.newIdentity(null, null, {
-        externalMgmtKey: address,
+        externalMgmtKey: normalizedAddress,
         mnemonic
       })
       // console.timeEnd('muport.newIdentity')
-      localstorage.set('serializedMuDID_' + address, muportDID.serializeState())
+      localstorage.set('serializedMuDID_' + normalizedAddress, muportDID.serializeState())
     }
     // console.time('new 3box')
     const box = new Box(muportDID, ethereumProvider, opts)
@@ -321,7 +322,7 @@ class Box {
    * @return    {Boolean}                           true if the user is logged in
    */
   static isLoggedIn (address) {
-    return Boolean(localstorage.get('serializedMuDID_' + address))
+    return Boolean(localstorage.get('serializedMuDID_' + address.toLowerCase()))
   }
 }
 


### PR DESCRIPTION
This way we're not making any assumptions about whether the addresses have been checksummed or not.

This is backwards-compatible with existing profiles created using 3box-dapp, as the addresses being used are already lower-cased.

Resolves #169