### PR TITLE
fix: connect to pin node directly, libp2p discovery servers not needed

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -153,6 +153,10 @@ class Box {
     } else {
       orbitdb = new OrbitDB(ipfs, opts.orbitPath)
     }
+
+    const pinningNode = opts.pinningNode || PINNING_NODE
+    ipfs.swarm.connect(pinningNode, () => {})
+
     const publicStore = new PublicStore(orbitdb)
 
     if (rootStoreAddress) {


### PR DESCRIPTION
Also connect to pinning node for getProfile. libp2p discovery nodes were throwing some errors the last few days, so lib could not find our ipfs node and sync the data.  