### PR TITLE
Add doc linking to contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+To view the contribution guide, go to the main 3box repo here:
+
+<https://github.com/uport-project/3box/blob/master/CONTRIBUTING.md>


### PR DESCRIPTION
Add doc linking to the contributor guide in the main 3box repo.